### PR TITLE
Update for play 2.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,11 +11,11 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 libraryDependencies ++= Seq(
   "args4j" % "args4j" % "2.0.25",
   "com.google.protobuf" % "protobuf-java" % "2.5.0",
-  "org.clojure" % "clojure" % "1.5.1",
-  "org.clojure" % "clojurescript" % "0.0-1934"
+  "org.clojure" % "clojure" % "1.6.0",
+  "org.clojure" % "clojurescript" % "0.0-2342"
 )
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.0")
 
 publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "io.github.petro-rudenko"
 
 name := "play-clojurescript"
 
-version := "0.0.1"
+version := "0.0.2"
 
 sbtPlugin := true
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/main/scala/assets/compiler/cljs/ClojurescriptCompiler.scala
+++ b/src/main/scala/assets/compiler/cljs/ClojurescriptCompiler.scala
@@ -6,7 +6,7 @@ import play.PlayExceptions._
 import sbt._
 
 
-object ClojureScriptCompiler {
+object ClojurescriptCompiler {
   val out = IO.createTemporaryDirectory
 
   def compile(src: File, options: Seq[String]): (String, Option[String], Seq[File]) = {
@@ -38,7 +38,6 @@ object ClojureScriptCompiler {
   private def compilePlainOptions: clojure.lang.IPersistentMap = {
     RT.map(
       Keyword intern "output-dir", out.absolutePath,
-      Keyword intern "output-to", null,
       Keyword intern "optimizations", Keyword intern "simple",
       Keyword intern "pretty-print", java.lang.Boolean.TRUE)
   }
@@ -49,7 +48,6 @@ object ClojureScriptCompiler {
   private def compileAdvancedOptions: clojure.lang.IPersistentMap = {
     RT.map(
       Keyword intern "output-dir", out.absolutePath,
-      Keyword intern "output-to", null,
       Keyword intern "optimizations", Keyword intern "advanced",
       Keyword intern "pretty-print", java.lang.Boolean.FALSE)
   }

--- a/src/main/scala/assets/compiler/cljs/ClojurescriptPlugin.scala
+++ b/src/main/scala/assets/compiler/cljs/ClojurescriptPlugin.scala
@@ -2,24 +2,24 @@ package assets.compiler.cljs
 
 import sbt._
 import sbt.Keys._
-import play.{Project => PlayProject}
+import play.Play.AssetsCompiler
 
-object ClojureScriptPlugin extends Plugin {
+object ClojurescriptPlugin extends Plugin {
   val clojureScriptEntryPoints =
     SettingKey[PathFinder]("play-clojurescript-entry-points")
   val clojureScriptOptions =
     SettingKey[Seq[String]]("play-clojurescript-options")
 
-  val clojureScriptCompiler = PlayProject.AssetsCompiler("clojurescript",
-    (_ ** "*.cljs"),
+  val clojureScriptCompiler = AssetsCompiler("clojurescript",
+    _ ** "*.cljs",
     clojureScriptEntryPoints,
     { (name, min) => name.replace(".cljs", if(min) ".min.js" else ".js") },
-    { ClojureScriptCompiler.compile },
+    { ClojurescriptCompiler.compile },
     clojureScriptOptions
   )
 
-  override val settings = Seq(
-    clojureScriptEntryPoints <<= (sourceDirectory in Compile)(base =>(base / "assets" ** "*.cljs") --- base / "assets" ** "_*"),
+  override def projectSettings = Seq(
+    clojureScriptEntryPoints <<= (sourceDirectory in Compile){base =>(base / "assets" ** "*.cljs") --- base / "assets" ** "_*"},
     clojureScriptOptions := Seq.empty[String],
     resourceGenerators in Compile <+= clojureScriptCompiler
   )


### PR DESCRIPTION
Update plugin to work with `Play 2.3`.

Updates:
- `Clojure` to `1.6.0`
- `Clojurescript` to `0.0-2342`
- `play.sbt-plugin` to `2.3.0`

The imports in `ClojurescriptPlugin` also needed to be changed because if `play 2.3`.

The reason for the change of the name from `ClojureScriptPlugin` to `ClojurescriptPlugin` was only because of naming conventions in my IDE, it doesn't really have to change.
